### PR TITLE
Node.js server from README doesn't serve eventsource.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ var fs = require('fs');
 
 http.createServer(function (req, res) {
   var t = 0;
-  if (req.url.indexOf('/events') === 0) {
+  if (req.url.indexOf('/events') === 0 && req.url.indexOf('/eventsource.js') === -1) {
 
     if (req.method === "OPTIONS") {
       res.writeHead(200, {


### PR DESCRIPTION
Node's server didn't respond to /eventsource.js with eventsource.js content, because it also starts with "/events". I've tried to fix it in the most non-invasive way.
