### PR TITLE
use native EventSource if available

### DIFF
--- a/eventsource.js
+++ b/eventsource.js
@@ -10,7 +10,7 @@
 (function (global) {
   "use strict";
 
-  if ("EventSource" in global) return;
+  if (typeof global.EventSource !== 'undefined') return;
 
   function Map() {
     this.data = {};

--- a/tests/eventsource.js
+++ b/tests/eventsource.js
@@ -10,7 +10,7 @@
 (function (global) {
   "use strict";
 
-  if ("EventSource" in global) return;
+  if (typeof global.EventSource !== 'undefined') return;
 
   function Map() {
     this.data = {};

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -1,20 +1,13 @@
 /*jslint indent: 2, vars: true, plusplus: true */
 /*global setTimeout, clearTimeout, navigator, window, location, asyncTest, EventSource, ok, strictEqual, start, XMLHttpRequest */
 
+this.EventSource = undefined;
+
 window.onload = function () {
   "use strict";
 
-  var nativeSupport = "EventSource" in window;
   var url = "/events";
   var url4CORS = "http://" + location.hostname + ":" + (String(location.port) === "8004" ? "8003" : "8004") + "/events";
-
-  if (nativeSupport) {
-    test("Native EventSource support", function () {
-      ok(nativeSupport);
-    });
-  }
-
-  if (nativeSupport) return;
 
   asyncTest("Cache-Control: no-cache", function () {
     var es = new EventSource(url + "?test=16");


### PR DESCRIPTION
This ensures native EventSource will be used if it's available.

As EventSource + CORS is now [more widely supported](https://github.com/Fyrd/caniuse/blob/master/features-json/eventsource.json#L22), this seems like a better default.

Currently the tests just exit if native support is detected. Probably a better solution would be to (somehow) force the tests to use the polyfill version.
