### PR TITLE
Remove duplicate main files from bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
   "name": "event-source-polyfill",
-  "version": "0.0.3",
-  "main": ["eventsource.js", "eventsource.min.js", "README.md"]
+  "version": "0.0.4",
+  "main": "eventsource.js"
 }


### PR DESCRIPTION
The main property in bower.json shouldn't have duplicate files. e.g. normal and minified versions.