### PR TITLE
Explicitly require grunt-cli and use an npm script to run it

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Specification:
 Build:
 ------
 
-* To build EventSource, just install grunt and this project devDependencies and run it. It should generate a new version of eventsource.min.js.
+* To build EventSource, just install npm modules (`npm install`) and then run the build (`npm run build`). It should generate a new version of eventsource.min.js.
 
 Notes:
 -----

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A polyfill for http://www.w3.org/TR/eventsource/ ",
   "main": "eventsource.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "build": "grunt"
   },
   "repository": {
     "type": "git",
@@ -25,6 +25,7 @@
   "homepage": "https://github.com/Yaffle/EventSource",
   "devDependencies": {
     "grunt": "^0.4.4",
+    "grunt-cli": "^0.1.13",
     "grunt-contrib-uglify": "~0.2.4"
   }
 }


### PR DESCRIPTION
Instead of asking users to perform a global install of the grunt cli (and hope that they have a compatible version), explicitly depend upon it in the `package.json` file. To execute the grunt command, I added a helper script: `npm run build`