### PR TITLE
Allow clients to override heartbeatTimeout

### DIFF
--- a/src/eventsource.js
+++ b/src/eventsource.js
@@ -415,7 +415,7 @@
     var withCredentials = options != undefined && Boolean(options.withCredentials);
 
     var initialRetry = clampDuration(1000);
-    var heartbeatTimeout = clampDuration(45000);
+    var heartbeatTimeout = options != undefined && options.heartbeatTimeout != undefined ? parseDuration(options.heartbeatTimeout, 45000) : clampDuration(45000);
 
     var lastEventId = "";
     var retry = initialRetry;


### PR DESCRIPTION
Allow clients using this library to pass in as an option "heartbeatTimeout" to override the default 45 second client timeout. 

@Yaffle: Could you please take a look?