### PR TITLE
Add usage info when using webpack or others.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,15 @@ Add anywhere you need access to EventSourcePolyfill class :
 declare var EventSourcePolyfill: any;
 ```
 
+Usage with webpack/browserify:
+------------------------------
+
+```javascript
+import { NativeEventSource, EventSourcePolyfill } from 'event-source-polyfill';
+
+const EventSource = NativeEventSource || EventSourcePolyfill;
+```
+
 Browser support:
 ----------------
 


### PR DESCRIPTION
This should fix #121. Not sure for #117, it seems to be different.