### PR TITLE
Do not crash Edge 15

### DIFF
--- a/src/eventsource.js
+++ b/src/eventsource.js
@@ -47,7 +47,8 @@
   }
 
   // see #118
-  if (fetch != undefined && fetch("data:text/plain,").finally == undefined) {
+  // We don't care about the content of the data URI, but Edge 15 will crash if the content is empty (#123), so make it one byte.
+  if (fetch != undefined && fetch("data:,a").finally == undefined) {
     var originalFetch = fetch;
     fetch = function (url, options) {
       return Promise.resolve(originalFetch(url, options));


### PR DESCRIPTION
When Edge 15 encounters
```javascript
window.fetch('data:text/plain,')
```
it crashes (the message is _This page is having a problem loading_).

The fix is simple: Make the data URI non empty.

While we're at it, also drop `text/plain` - that's not necessary per [spec](https://tools.ietf.org/html/rfc2397) and just bloats the code unnecessarily.