### PR TITLE
in readme show that EventSource (for webpack) may need to be set as global property

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ Usage with webpack/browserify:
 import { NativeEventSource, EventSourcePolyfill } from 'event-source-polyfill';
 
 const EventSource = NativeEventSource || EventSourcePolyfill;
+// OR: may also need to set as global property
+global.EventSource =  NativeEventSource || EventSourcePolyfill;
 ```
 
 Browser support:


### PR DESCRIPTION
For webpack to reference EventSource may need to add as global property - I didn't think this was too obvious, and it took time to figure this out.