### PR TITLE
Add finally function to then returns for Edge

### DIFF
--- a/src/eventsource.js
+++ b/src/eventsource.js
@@ -53,7 +53,12 @@
   if (fetch != undefined && true) {
     var originalFetch = fetch;
     fetch = function (url, options) {
-      return Promise.resolve(originalFetch(url, options));
+      var promise = Promise.resolve(originalFetch(url, options));
+      var originalThen = promise.then;
+      Promise.prototype["then"] = function () {
+        return Promise.resolve(originalThen.apply(this, arguments));
+      };
+      return promise;
     };
   }
 


### PR DESCRIPTION
When load `EventSourcePolyfill` on Edge, we have an error (Unhandled promise rejection TypeError: Object doesn't support property or method 'finally')

This was because the return of our Promise did not include a `finally` method.

Environment :
browsers : Edge18
event-source-polyfill : 1.0.8
core-js : 3.4.2
webpack : 4.35.3
It seems to be correlated with https://github.com/Yaffle/EventSource/issues/118