### PR TITLE
Replace lastEventId GET parameter in Request-URL if it's already definded

### DIFF
--- a/src/eventsource.js
+++ b/src/eventsource.js
@@ -965,10 +965,10 @@
 
       // https://bugzilla.mozilla.org/show_bug.cgi?id=428916
       // Request header field Last-Event-ID is not allowed by Access-Control-Allow-Headers.
-      var requestURL = url;
+      var requestURL = new URL(url);
       if (url.slice(0, 5) !== "data:" && url.slice(0, 5) !== "blob:") {
         if (lastEventId !== "") {
-          requestURL += (url.indexOf("?") === -1 ? "?" : "&") + lastEventIdQueryParameterName +"=" + encodeURIComponent(lastEventId);
+          requestURL.searchParams.set(lastEventIdQueryParameterName, lastEventId);
         }
       }
       var withCredentials = es.withCredentials;
@@ -983,7 +983,7 @@
         }
       }
       try {
-        abortController = transport.open(xhr, onStart, onProgress, onFinish, requestURL, withCredentials, requestHeaders);
+        abortController = transport.open(xhr, onStart, onProgress, onFinish, requestURL.toString(), withCredentials, requestHeaders);
       } catch (error) {
         close();
         throw error;


### PR DESCRIPTION
I'm using [mercure](https://mercure.rocks/) as SEE server.

To get all messages the user "missed" while the app was closed, I append the last event ID to the initialization of `EventSourcePolyfill`. In my case, the value of `lastEventId` is stored in the local storage of the app.

```typescript
const url = new URL(eventStreamUrl);
url.searchParams.append('topic', 'chat-messages');

// Append to ID of the last fetched event to the request to get all events missed while the app was closed.
url.searchParams.append('Last-Event-ID', lastEventId);

this.eventSource = new EventSourcePolyfill(url, {
  lastEventIdQueryParameterName: 'Last-Event-ID',
  headers: {
    Authorization: `Bearer ...`
  }
});
```

When EventSource is reconnecting to the SSE server, the Last-Event-ID known to EventSourcePolyfill is appended to the request URL. This causes the parameter `Last-Event-ID` to be contained in the request URL twice:

```
https://SSE-SERVER/.well-known/mercure?topic=chat-messages&Last-Event-ID=urn%3Auuid%3A...AAA&Last-Event-ID=urn%3Auuid%3A...BBB
```

This causes failed reconnects to the SSE server because of the duplicate GET parameters.
That's why I changed the code to use `URLSearchParams.set(...)`  to set/add the parameter `Last-Event-ID`. If the parameter `Last-Event-ID` is already there (for example because of my `EventSourcePolyfill` initialization), it will be replaced by the latest `Last-Event-ID`.